### PR TITLE
Implement asynchronous Gmail provider

### DIFF
--- a/EmailTools/AllEmails.py
+++ b/EmailTools/AllEmails.py
@@ -1,8 +1,164 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Optional
+
+from .abc import AsyncEmailProvider, AddressListLike
+from .models import AccountInfo, Attachment, Draft, EmailMessage
 
 
 class AllEmails:
+    """A multiaccount email manager.
+
+    This class acts as a thin wrapper around multiple
+    :class:`~EmailTools.abc.AsyncEmailProvider` instances. It mirrors the
+    provider API but requires an ``account`` parameter to identify which
+    provider should handle the call.
     """
-    A multiaccount email manager.
-    TODO: have almost same methods as AsyncEmailProvider, but have an extra param for accounts
-        and have account management functions, like get_accounts.
-    """
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, AsyncEmailProvider] = {}
+
+    # ------------------------------------------------------------------
+    # Account management
+    # ------------------------------------------------------------------
+    def register(self, provider: AsyncEmailProvider) -> None:
+        """Register a provider instance for its account name."""
+
+        self._providers[provider.account.name] = provider
+
+    def unregister(self, account: str) -> None:
+        """Remove a provider from management if present."""
+
+        self._providers.pop(account, None)
+
+    def get_accounts(self) -> List[AccountInfo]:
+        """Return metadata for all managed accounts."""
+
+        return [p.account for p in self._providers.values()]
+
+    def _get(self, account: str) -> AsyncEmailProvider:
+        if account not in self._providers:
+            raise KeyError(f"Account '{account}' is not registered")
+        return self._providers[account]
+
+    # ------------------------------------------------------------------
+    # Methods mirroring AsyncEmailProvider with an extra `account` param
+    # ------------------------------------------------------------------
+    async def fetch_unread(
+        self, account: str, *, max_results: int = 10, include_body: bool = False
+    ) -> List[EmailMessage]:
+        provider = self._get(account)
+        return await provider.fetch_unread(
+            max_results=max_results, include_body=include_body
+        )
+
+    async def count_unread(self, account: str) -> int:
+        provider = self._get(account)
+        return await provider.count_unread()
+
+    async def send_email(
+        self,
+        account: str,
+        *,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.send_email(
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+    async def mark_read(self, account: str, message_ids: List[str]) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.mark_read(message_ids)
+
+    async def mark_unread(self, account: str, message_ids: List[str]) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.mark_unread(message_ids)
+
+    async def delete_message(
+        self, account: str, message_id: str, *, permanent: bool = False
+    ) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.delete_message(message_id, permanent=permanent)
+
+    async def create_draft(
+        self,
+        account: str,
+        *,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Draft:
+        provider = self._get(account)
+        return await provider.create_draft(
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+    async def update_draft(
+        self,
+        account: str,
+        *,
+        draft_id: str,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Draft:
+        provider = self._get(account)
+        return await provider.update_draft(
+            draft_id=draft_id,
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+    async def send_draft(self, account: str, *, draft_id: str) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.send_draft(draft_id=draft_id)
+
+    async def list_drafts(
+        self, account: str, *, max_results: int = 10
+    ) -> List[Draft]:
+        provider = self._get(account)
+        return await provider.list_drafts(max_results=max_results)
+
+    async def get_draft(self, account: str, *, draft_id: str) -> Draft:
+        provider = self._get(account)
+        return await provider.get_draft(draft_id=draft_id)
+
+    async def delete_draft(self, account: str, *, draft_id: str) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.delete_draft(draft_id=draft_id)
+
+    async def get_summary(self, account: str) -> Dict[str, Any]:
+        provider = self._get(account)
+        return await provider.get_summary()

--- a/EmailTools/Providers/GmailClient.py
+++ b/EmailTools/Providers/GmailClient.py
@@ -1,5 +1,490 @@
-from ..abc import AsyncEmailProvider
+"""Gmail provider implementation.
+
+This module implements :class:`GmailClient` which provides an asynchronous
+wrapper around the Gmail API.  The class adheres to the
+``AsyncEmailProvider`` interface defined in :mod:`EmailTools.abc`.
+
+The implementation purposefully keeps the logic lightweight and relies on
+``asyncio.to_thread`` to run the blocking Google API client in a thread.  The
+configuration is sourced from :mod:`EmailTools.config` which exposes the
+``Config`` object at package import time.
+
+The class only implements a subset of the Gmail functionality required by the
+abstract base class.  The methods cover common actions such as fetching unread
+messages, sending mail, working with drafts and updating message state.  Each
+method returns domain models defined in :mod:`EmailTools.models`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+from email.message import EmailMessage as _EmailMessage
+from email.utils import getaddresses, parseaddr
+from typing import Any, Dict, List, Optional, Sequence
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+from .. import config
+from ..abc import AsyncEmailProvider, AddressListLike
+from ..models import (
+    AccountInfo,
+    Attachment,
+    Draft,
+    EmailAddress,
+    EmailMessage,
+)
+
 
 class GmailClient(AsyncEmailProvider):
-    """Gmail client"""
-    # TODO: finish this class
+    """Concrete :class:`AsyncEmailProvider` for Google's Gmail service."""
+
+    #: Scopes used for Gmail access.  These provide read/write access as well as
+    #: draft and send capabilities.
+    SCOPES: Sequence[str] = (
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.send",
+    )
+
+    def __init__(self, account: AccountInfo, secrets: Dict[str, str]):
+        super().__init__(account, secrets)
+
+        creds: Optional[Credentials] = None
+        token_name = f"{account.name}_gmail.json"
+        token_path = (
+            os.path.join(config.TOKEN_PATH, token_name)
+            if config.TOKEN_PATH
+            else token_name
+        )
+        # Ensure the token directory exists before attempting to read/write.
+        token_dir = os.path.dirname(token_path)
+        if token_dir:
+            os.makedirs(token_dir, exist_ok=True)
+
+        if os.path.exists(token_path):
+            creds = Credentials.from_authorized_user_file(token_path, self.SCOPES)
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                try:
+                    creds.refresh(Request())
+                except Exception:
+                    creds = None
+            if not creds or not creds.valid:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    config.GOOGLE_CREDENTIALS_PATH, self.SCOPES
+                )
+                creds = flow.run_local_server(port=0)
+            # Persist the refreshed/created credentials so the user does not
+            # need to re-authenticate every run.
+            with open(token_path, "w") as token_file:
+                token_file.write(creds.to_json())
+
+        # ``build`` creates a synchronous client – we will execute its calls in a
+        # background thread using ``asyncio.to_thread``.
+        self.service = build("gmail", "v1", credentials=creds)
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _parse_address(self, value: str) -> EmailAddress:
+        name, email = parseaddr(value)
+        return EmailAddress(email=email, name=name or None)
+
+    def _parse_address_list(self, value: Optional[str]) -> List[EmailAddress]:
+        if not value:
+            return []
+        return [
+            EmailAddress(email=addr[1], name=addr[0] or None)
+            for addr in getaddresses([value])
+        ]
+
+    def _extract_plain_body(self, payload: Dict[str, Any]) -> Optional[str]:
+        """Return the plain text body from a Gmail API ``payload`` dict."""
+        if "body" in payload and payload.get("mimeType") == "text/plain":
+            data = payload["body"].get("data")
+            if data:
+                return base64.urlsafe_b64decode(data).decode("utf-8", errors="ignore")
+        for part in payload.get("parts", []) or []:
+            text = self._extract_plain_body(part)
+            if text:
+                return text
+        return None
+
+    def _build_message(
+        self,
+        *,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> _EmailMessage:
+        def _fmt(a: Any) -> str:
+            if isinstance(a, EmailAddress):
+                return f"{a.name} <{a.email}>" if a.name else a.email
+            return str(a)
+
+        msg = _EmailMessage()
+        msg["To"] = to if isinstance(to, str) else ", ".join(_fmt(a) for a in to)
+        if cc:
+            msg["Cc"] = cc if isinstance(cc, str) else ", ".join(_fmt(a) for a in cc)
+        if bcc:
+            msg["Bcc"] = bcc if isinstance(bcc, str) else ", ".join(_fmt(a) for a in bcc)
+        msg["Subject"] = subject
+        if html_body:
+            msg.add_alternative(html_body, subtype="html")
+            msg.set_content(body_text)
+        else:
+            msg.set_content(body_text)
+
+        # Attachments
+        for attachment in attachments or []:
+            if attachment.file_path:
+                with open(attachment.file_path, "rb") as f:
+                    data = f.read()
+                maintype, subtype = (attachment.mime_type or "application/octet-stream").split(
+                    "/", 1
+                )
+                msg.add_attachment(
+                    data, maintype=maintype, subtype=subtype, filename=attachment.filename
+                )
+            elif attachment.content_bytes:
+                data = base64.b64decode(attachment.content_bytes)
+                maintype, subtype = (attachment.mime_type or "application/octet-stream").split(
+                    "/", 1
+                )
+                msg.add_attachment(
+                    data, maintype=maintype, subtype=subtype, filename=attachment.filename
+                )
+
+        return msg
+
+    def _gmail_message(self, message: _EmailMessage) -> Dict[str, Any]:
+        encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
+        return {"raw": encoded_message}
+
+    def _parse_gmail_message(self, msg: Dict[str, Any]) -> EmailMessage:
+        payload = msg.get("payload", {})
+        headers = {h["name"]: h["value"] for h in payload.get("headers", [])}
+        subject = headers.get("Subject", "")
+        to_header = headers.get("To")
+        cc_header = headers.get("Cc")
+        bcc_header = headers.get("Bcc")
+        from_header = headers.get("From", "")
+
+        return EmailMessage(
+            id=msg["id"],
+            account=self.account.name,
+            subject=subject,
+            from_=self._parse_address(from_header),
+            to=self._parse_address_list(to_header),
+            cc=self._parse_address_list(cc_header),
+            bcc=self._parse_address_list(bcc_header),
+            snippet=msg.get("snippet"),
+            body_text=self._extract_plain_body(payload),
+            labels=list(msg.get("labelIds", [])),
+            is_read="UNREAD" not in msg.get("labelIds", []),
+            raw_provider_payload=msg,
+        )
+
+    # ------------------------------------------------------------------
+    # API methods implementing AsyncEmailProvider
+    # ------------------------------------------------------------------
+    async def fetch_unread(
+        self, *, max_results: int = 10, include_body: bool = False
+    ) -> List[EmailMessage]:
+        def _inner() -> List[EmailMessage]:
+            res = (
+                self.service.users()
+                .messages()
+                .list(userId="me", q="is:unread", maxResults=max_results)
+                .execute()
+            )
+            messages = []
+            for item in res.get("messages", []):
+                msg = (
+                    self.service.users()
+                    .messages()
+                    .get(
+                        userId="me",
+                        id=item["id"],
+                        format="full" if include_body else "metadata",
+                    )
+                    .execute()
+                )
+                messages.append(self._parse_gmail_message(msg))
+            return messages
+
+        return await asyncio.to_thread(_inner)
+
+    async def count_unread(self) -> int:
+        def _inner() -> int:
+            res = (
+                self.service.users()
+                .messages()
+                .list(userId="me", q="is:unread", maxResults=1)
+                .execute()
+            )
+            return int(res.get("resultSizeEstimate", 0))
+
+        return await asyncio.to_thread(_inner)
+
+    async def send_email(
+        self,
+        *,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Dict[str, Any]:
+        message = self._build_message(
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+        def _inner() -> Dict[str, Any]:
+            return (
+                self.service.users()
+                .messages()
+                .send(userId="me", body=self._gmail_message(message))
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def mark_read(self, message_ids: List[str]) -> Dict[str, Any]:
+        def _inner() -> Dict[str, Any]:
+            return (
+                self.service.users()
+                .messages()
+                .batchModify(
+                    userId="me",
+                    body={"ids": message_ids, "removeLabelIds": ["UNREAD"]},
+                )
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def mark_unread(self, message_ids: List[str]) -> Dict[str, Any]:
+        def _inner() -> Dict[str, Any]:
+            return (
+                self.service.users()
+                .messages()
+                .batchModify(
+                    userId="me", body={"ids": message_ids, "addLabelIds": ["UNREAD"]}
+                )
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def delete_message(self, message_id: str, *, permanent: bool = False) -> Dict[str, Any]:
+        def _inner() -> Dict[str, Any]:
+            if permanent:
+                return (
+                    self.service.users()
+                    .messages()
+                    .delete(userId="me", id=message_id)
+                    .execute()
+                )
+            return (
+                self.service.users()
+                .messages()
+                .trash(userId="me", id=message_id)
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def create_draft(
+        self,
+        *,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Draft:
+        msg = self._build_message(
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+        def _inner() -> Draft:
+            res = (
+                self.service.users()
+                .drafts()
+                .create(userId="me", body={"message": self._gmail_message(msg)})
+                .execute()
+            )
+            message = self._parse_gmail_message(res.get("message", {}))
+            return Draft(
+                id=res["id"],
+                account=self.account.name,
+                to=message.to,
+                cc=message.cc,
+                bcc=message.bcc,
+                subject=message.subject,
+                body_text=message.body_text,
+                body_html=None,
+                raw_provider_payload=res,
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def update_draft(
+        self,
+        *,
+        draft_id: str,
+        to: AddressListLike,
+        subject: str,
+        body_text: str,
+        cc: Optional[AddressListLike] = None,
+        bcc: Optional[AddressListLike] = None,
+        html_body: Optional[str] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+    ) -> Draft:
+        msg = self._build_message(
+            to=to,
+            subject=subject,
+            body_text=body_text,
+            cc=cc,
+            bcc=bcc,
+            html_body=html_body,
+            attachments=attachments,
+        )
+
+        def _inner() -> Draft:
+            res = (
+                self.service.users()
+                .drafts()
+                .update(
+                    userId="me",
+                    id=draft_id,
+                    body={"message": self._gmail_message(msg), "id": draft_id},
+                )
+                .execute()
+            )
+            message = self._parse_gmail_message(res.get("message", {}))
+            return Draft(
+                id=res["id"],
+                account=self.account.name,
+                to=message.to,
+                cc=message.cc,
+                bcc=message.bcc,
+                subject=message.subject,
+                body_text=message.body_text,
+                body_html=None,
+                raw_provider_payload=res,
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def send_draft(self, *, draft_id: str) -> Dict[str, Any]:
+        def _inner() -> Dict[str, Any]:
+            return (
+                self.service.users()
+                .drafts()
+                .send(userId="me", body={"id": draft_id})
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def list_drafts(self, *, max_results: int = 10) -> List[Draft]:
+        def _inner() -> List[Draft]:
+            res = (
+                self.service.users()
+                .drafts()
+                .list(userId="me", maxResults=max_results)
+                .execute()
+            )
+            drafts = []
+            for item in res.get("drafts", []):
+                draft = (
+                    self.service.users()
+                    .drafts()
+                    .get(userId="me", id=item["id"])
+                    .execute()
+                )
+                message = self._parse_gmail_message(draft.get("message", {}))
+                drafts.append(
+                    Draft(
+                        id=item["id"],
+                        account=self.account.name,
+                        to=message.to,
+                        cc=message.cc,
+                        bcc=message.bcc,
+                        subject=message.subject,
+                        body_text=message.body_text,
+                        body_html=None,
+                        raw_provider_payload=draft,
+                    )
+                )
+            return drafts
+
+        return await asyncio.to_thread(_inner)
+
+    async def get_draft(self, *, draft_id: str) -> Draft:
+        def _inner() -> Draft:
+            res = (
+                self.service.users()
+                .drafts()
+                .get(userId="me", id=draft_id)
+                .execute()
+            )
+            message = self._parse_gmail_message(res.get("message", {}))
+            return Draft(
+                id=res["id"],
+                account=self.account.name,
+                to=message.to,
+                cc=message.cc,
+                bcc=message.bcc,
+                subject=message.subject,
+                body_text=message.body_text,
+                body_html=None,
+                raw_provider_payload=res,
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def delete_draft(self, *, draft_id: str) -> Dict[str, Any]:
+        def _inner() -> Dict[str, Any]:
+            return (
+                self.service.users()
+                .drafts()
+                .delete(userId="me", id=draft_id)
+                .execute()
+            )
+
+        return await asyncio.to_thread(_inner)
+
+    async def get_summary(self) -> Dict[str, Any]:
+        unread = await self.count_unread()
+        return {"account": self.account.name, "unread": unread}
+

--- a/EmailTools/__init__.py
+++ b/EmailTools/__init__.py
@@ -1,3 +1,37 @@
 from .config import Config
+from .tools import (
+    add_account,
+    list_email_accounts,
+    email_fetch_unread,
+    email_send,
+    email_mark_read,
+    email_mark_unread,
+    email_delete_message,
+    email_count_unread,
+    email_create_draft,
+    email_update_draft,
+    email_send_draft,
+    email_list_drafts,
+    email_get_draft,
+    email_delete_draft,
+)
 
 config = Config()
+
+__all__ = [
+    "add_account",
+    "list_email_accounts",
+    "email_fetch_unread",
+    "email_send",
+    "email_mark_read",
+    "email_mark_unread",
+    "email_delete_message",
+    "email_count_unread",
+    "email_create_draft",
+    "email_update_draft",
+    "email_send_draft",
+    "email_list_drafts",
+    "email_get_draft",
+    "email_delete_draft",
+    "config",
+]

--- a/EmailTools/tools.py
+++ b/EmailTools/tools.py
@@ -1,4 +1,196 @@
-"""
-This file write the functional tools that exposed out
-"""
+"""Email related tools exposed for the agent framework."""
+
+from dataclasses import asdict
+from typing import Optional, Sequence
+
 from langchain_core.tools import tool
+
+from .AllEmails import AllEmails
+from .Providers.GmailClient import GmailClient
+from .abc import AddressListLike
+from .models import AccountInfo, Attachment, Draft
+
+# A single manager instance used by all tools
+email_manager = AllEmails()
+
+# Mapping of supported provider identifiers to their client classes
+PROVIDERS = {
+    "gmail": GmailClient,
+}
+
+
+@tool("add_account")
+def add_account(provider: str, name: str, email: str) -> str:
+    """Add a new email account for the specified provider."""
+
+    provider_key = provider.lower()
+    provider_cls = PROVIDERS.get(provider_key)
+    if not provider_cls:
+        return f"provider '{provider}' is not supported"
+
+    account = AccountInfo(name=name, provider=provider_key, email=email)
+    email_manager.register(provider_cls(account, {}))
+    return f"registered {name}"
+
+
+@tool("list_email_accounts")
+def list_email_accounts() -> list:
+    """Return a list of registered email accounts."""
+
+    return [asdict(acc) for acc in email_manager.get_accounts()]
+
+
+@tool("email_fetch_unread")
+async def email_fetch_unread(
+    account: str, max_results: int = 10, include_body: bool = False
+) -> list:
+    """Fetch unread messages for the given account."""
+
+    msgs = await email_manager.fetch_unread(
+        account, max_results=max_results, include_body=include_body
+    )
+    return [asdict(m) for m in msgs]
+
+
+@tool("email_send")
+async def email_send(
+    account: str,
+    *,
+    to: AddressListLike,
+    subject: str,
+    body_text: str,
+    cc: Optional[AddressListLike] = None,
+    bcc: Optional[AddressListLike] = None,
+    html_body: Optional[str] = None,
+    attachments: Optional[Sequence[Attachment]] = None,
+) -> dict:
+    """Send an email using the specified account."""
+
+    return await email_manager.send_email(
+        account,
+        to=to,
+        subject=subject,
+        body_text=body_text,
+        cc=cc,
+        bcc=bcc,
+        html_body=html_body,
+        attachments=attachments,
+    )
+
+
+@tool("email_mark_read")
+async def email_mark_read(account: str, message_ids: Sequence[str]) -> dict:
+    """Mark the given message ids as read for an account."""
+
+    return await email_manager.mark_read(account, list(message_ids))
+
+
+@tool("email_mark_unread")
+async def email_mark_unread(account: str, message_ids: Sequence[str]) -> dict:
+    """Mark the given message ids as unread for an account."""
+
+    return await email_manager.mark_unread(account, list(message_ids))
+
+
+@tool("email_delete_message")
+async def email_delete_message(
+    account: str, message_id: str, *, permanent: bool = False
+) -> dict:
+    """Delete a message; use ``permanent=True`` to skip trash."""
+
+    return await email_manager.delete_message(account, message_id, permanent=permanent)
+
+
+@tool("email_count_unread")
+async def email_count_unread(account: str) -> int:
+    """Return the number of unread messages for an account."""
+
+    return await email_manager.count_unread(account)
+
+
+@tool("email_create_draft")
+async def email_create_draft(
+    account: str,
+    *,
+    to: AddressListLike,
+    subject: str,
+    body_text: str,
+    cc: Optional[AddressListLike] = None,
+    bcc: Optional[AddressListLike] = None,
+    html_body: Optional[str] = None,
+    attachments: Optional[Sequence[Attachment]] = None,
+) -> dict:
+    """Create a draft email and return its metadata."""
+
+    draft: Draft = await email_manager.create_draft(
+        account,
+        to=to,
+        subject=subject,
+        body_text=body_text,
+        cc=cc,
+        bcc=bcc,
+        html_body=html_body,
+        attachments=attachments,
+    )
+    return asdict(draft)
+
+
+@tool("email_update_draft")
+async def email_update_draft(
+    account: str,
+    *,
+    draft_id: str,
+    to: AddressListLike,
+    subject: str,
+    body_text: str,
+    cc: Optional[AddressListLike] = None,
+    bcc: Optional[AddressListLike] = None,
+    html_body: Optional[str] = None,
+    attachments: Optional[Sequence[Attachment]] = None,
+) -> dict:
+    """Update an existing draft."""
+
+    draft: Draft = await email_manager.update_draft(
+        account,
+        draft_id=draft_id,
+        to=to,
+        subject=subject,
+        body_text=body_text,
+        cc=cc,
+        bcc=bcc,
+        html_body=html_body,
+        attachments=attachments,
+    )
+    return asdict(draft)
+
+
+@tool("email_send_draft")
+async def email_send_draft(account: str, *, draft_id: str) -> dict:
+    """Send a previously created draft."""
+
+    return await email_manager.send_draft(account, draft_id=draft_id)
+
+
+@tool("email_list_drafts")
+async def email_list_drafts(account: str, max_results: int = 10) -> list:
+    """List drafts for an account."""
+
+    drafts = await email_manager.list_drafts(account, max_results=max_results)
+    return [asdict(d) for d in drafts]
+
+
+@tool("email_get_draft")
+async def email_get_draft(account: str, *, draft_id: str) -> dict:
+    """Retrieve a single draft by id."""
+
+    draft = await email_manager.get_draft(account, draft_id=draft_id)
+    return asdict(draft)
+
+
+@tool("email_delete_draft")
+async def email_delete_draft(account: str, *, draft_id: str) -> dict:
+    """Delete a draft."""
+
+    return await email_manager.delete_draft(account, draft_id=draft_id)
+
+


### PR DESCRIPTION
## Summary
- improve Gmail OAuth handling with token directory creation, refresh retry, and fallback to OAuth flow
- add email tools for marking read/unread, deleting messages, counting unread, and full draft management
- introduce generic add_account tool for registering email accounts by provider with safety checks for unsupported providers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac7466cf88333a767d3e83bff8324