### PR TITLE
Refactor tool execution to avoid nested event loops

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -39,11 +39,14 @@ class Engine:
                 pass
 
         # Build graph with closures capturing LLMs and tools
+        async def _executor(state, llm=self._executor_llm, tools=self._tools):
+            return await executor_node(state, llm, tools)
+
         self.app = build_graph(
             {
                 "router": lambda state: router_node(state, self._router_llm),
                 "planner": lambda state: planner_node(state, self._planner_llm),
-                "executor": lambda state: executor_node(state, self._executor_llm, self._tools),
+                "executor": _executor,
                 "critic": lambda state: critical_node(state, self._critic_llm),
             }
         )


### PR DESCRIPTION
## Summary
- handle async tool calls concurrently without spawning new event loops
- make executor node async to await tool execution results
- wrap executor node in async closure so graph awaits and returns state updates

## Testing
- `python -m py_compile core/engine.py core/nodes.py`
- `pytest -q` *(fails: Missing required API config: OPENROUTER_API_KEY, OPENAI_BASE_URL, ROUTER_MODEL, PLANNER_MODEL, EXECUTOR_MODEL, CRITIC_MODEL)*

------
https://chatgpt.com/codex/tasks/task_e_68ab47d91268833392992afaf3ac5fc7